### PR TITLE
fix typo in branch name example

### DIFF
--- a/CONTRIBUTORS.adoc
+++ b/CONTRIBUTORS.adoc
@@ -72,7 +72,7 @@ To submit a pull request,
 IMPORTANT: If you haven't been added as a collaborator to the link:{github-repo}[{project-name}] repo, you will need to either https://docs.github.com/en/get-started/quickstart/fork-a-repo[fork] the repo or contact the repo admin to request write access. If you've forked the repo, be sure to https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/syncing-a-fork[sync your forked repo] in order to avoid potential merge conflicts.
 
 . https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository#creating-a-branch[Create a new branch] in the link:{github-repo}[{project-name}] repo.
-The branch name should be prepended with its associated issue label followed by a `/`, followed by a `dash-separated` description of the changes to be made, followed by its associated issue number, e.g., `feature/add-tricoder-with-touchscreen-docs-1701`. If no such issue exists, link:{doc-name}#opening-an-issue[open an issue].
+Make sure the branch name follows the content style guide for link:{doc-name}#naming-a-branch[naming a branch].
 . As you edit your content, ensure that it conforms to the link:{doc-name}#content-style-guide[content style guide].
 . Commit your changes and https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request[create a pull request]. Be sure to include a https://docs.github.com/en/enterprise/2.16/user/github/managing-your-work-on-github/closing-issues-using-keywords[closing keyword] followed by the associated issue number in the pull request description, e.g., `closes #1701`. If the pull request closes multiple issues, add a closing keyword for each issue.
 
@@ -92,6 +92,12 @@ Content in `architecture/` should be consistent with the https://github.com/Mach
 === Components
 
 `package.json` files for components in the `components` directory (and subdirectories) should conform to the specification for a https://mach30.github.io/dof/#_component[DOF-Component].
+
+=== Naming a branch
+
+Branch names should be all lowercase, prepended with its associated issue label, followed by a `dash-separated` description of the changes to be made, followed by its associated issue number, and delimited by a forward slash, `/`.
+e.g., `feature/add-tricoder-with-touchscreen-docs/1701`.
+If no such issue exists, link:{doc-name}#opening-an-issue[open an issue].
 
 == Semantic versioning
 


### PR DESCRIPTION
- create subsection for "Naming a branch"
- update verbiage to include all lowercase, and delimited by a forward slash
- update example to include '/' between issue description & issue number

closes #140 